### PR TITLE
attempt trailing slash fix http://serverfault.com/a/542038/264016

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -38,6 +38,7 @@ http {
     root <%= ENV["ROOT_DIRECTORY"] || 'html' %>;
     index index.html;
     resolver 8.8.8.8;
+    port_in_redirect off;
 
     <% if ENV["FORCE_HTTPS"] %>
       if ( $http_x_forwarded_proto != 'https' ) {


### PR DESCRIPTION
This pull request fixes the common trailing slash-redirect as described here: http://serverfault.com/questions/351212/nginx-redirects-to-port-8080-when-accessing-url-without-slash/542038
